### PR TITLE
Fix hasRole() returning true if user, in fact, doesn't have the role

### DIFF
--- a/src/lib/Model/User.php
+++ b/src/lib/Model/User.php
@@ -259,11 +259,7 @@ class User extends FlexibleEntity implements UserInterface
      */
     public function hasRole($role = null)
     {
-        try {
-            return array_search($role, $this->get('roles')) !== null;
-        } catch (\Exception $e) {
-            return false;
-        }
+        return in_array($role, $this->get('roles'), true) === true;
     }
 
     /**


### PR DESCRIPTION
Just ran into an issue where a user didn't have a role, but `hasRole()` returned `true`, because `array_search()` [evaluates to](http://php.net/manual/en/function.array-search.php) `false` in this case, which is not `null`, and so `hasRole()` returns `true` although the role isn't there.

The [PHP docs mention](http://php.net/manual/en/function.array-search.php) that `array_search()` can, however, in fact return `null` in case the input was malformed.

So I looked into how FOSUserBundle does it, and they [seem to use in_array()](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Model/User.php#L287).

I also removed the try-catch block because the built-in PHP functions unfortunately don't throw any Exceptions, so trying to catch them could be misleading.